### PR TITLE
Fix build command of golang project

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "backend-boilerplate",
   "version": "1.0.0",
   "scripts": {
-    "build": "cd app && go build server.go",
+    "build": "cd app && go build",
     "start": "./app/server",
     "test": "cypress run"
   },


### PR DESCRIPTION
You should use `go build` command to build the go project.
You cannot assume this app is a single go source file project.